### PR TITLE
Adapt to the refactored role names

### DIFF
--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -10,6 +10,18 @@
     - python3-pyyaml
   become: true
 
-- name: Run example CNF role
+- name: Deploy NFV Example CNF catalog
   include_role:
-    name: "{{ dci_config_dir }}/hooks/nfv-example-cnf-deploy/roles/nfv-example-cnf"
+    name: "{{ dci_config_dir }}/hooks/nfv-example-cnf-deploy/roles/example-cnf-catalog"
+
+- name: Label the nodes for running testpmd and trex
+  include_role:
+    name: "{{ dci_config_dir }}/hooks/nfv-example-cnf-deploy/roles/example-cnf-labels"
+
+- name: Deploy the Example CNF applications
+  include_role:
+    name: "{{ dci_config_dir }}/hooks/nfv-example-cnf-deploy/roles/example-cnf-app"
+
+- name: Run migration test
+  include_role:
+    name: "{{ dci_config_dir }}/hooks/nfv-example-cnf-deploy/roles/example-cnf-validate"

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -1,7 +1,7 @@
 ---
 - name: Checkout Example CNF deployment role
   git:
-    repo: 'https://github.com/krsacme/nfv-example-cnf-deploy.git'
+    repo: 'https://github.com/rh-nfv-int/nfv-example-cnf-deploy.git'
     dest: "{{ dci_config_dir }}/hooks/nfv-example-cnf-deploy"
     update: yes
   register: gitresult


### PR DESCRIPTION
Refecatored roles to separte each major step as a role. Also added labeling of the nodes using a custom operator.

example-cnf-catalog
example-cnf-labels
example-cnf-app
example-cnf-validate
