### PR TITLE
install: call the package manager once

### DIFF
--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -1,13 +1,12 @@
 ---
 - name: 'Install required rpm packages'
   package:
-    name: "{{ item }}"
+    name:
+      - git
+      - make
+      - python3-openshift
+      - python3-pyyaml
     state: latest
-  loop:
-    - git
-    - make
-    - python3-openshift
-    - python3-pyyaml
   become: true
 
 - name: Deploy NFV Example CNF catalog


### PR DESCRIPTION
When using the package module with a loop then the package manager is
executed X times where X is the length of the list.
The package module can already handle a list as input to avoid this
behaviour.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>