### PR TITLE
Use the role name instead of full path

### DIFF
--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -11,8 +11,8 @@
 
 - name: Deploy NFV Example CNF catalog
   include_role:
-    name: "{{ dci_config_dir }}/hooks/nfv-example-cnf-deploy/roles/example-cnf-catalog"
+    name: example-cnf-catalog
 
 - name: Label the nodes for running testpmd and trex
   include_role:
-    name: "{{ dci_config_dir }}/hooks/nfv-example-cnf-deploy/roles/example-cnf-labels"
+    name: example-cnf-labels

--- a/testpmd/hooks/user-tests.yml
+++ b/testpmd/hooks/user-tests.yml
@@ -2,7 +2,7 @@
 # TODO(skramaja): Move this to install as this is not a test
 - name: Deploy the Example CNF applications
   include_role:
-    name: "{{ dci_config_dir }}/hooks/nfv-example-cnf-deploy/roles/example-cnf-app"
+    name: example-cnf-app
 
 - name: Wait for trex to stablize
   pause:
@@ -10,4 +10,4 @@
 
 - name: Run migration test
   include_role:
-    name: "{{ dci_config_dir }}/hooks/nfv-example-cnf-deploy/roles/example-cnf-validate"
+    name: example-cnf-validate


### PR DESCRIPTION
example-cnf roles path is added to the ansible cfg
in the pipeline repo. It is no longer required to use
full path name of the role.

build-depends: https://github.com/dallas-telco-lab/pipelines/pull/12