### PR TITLE
Align the catalogsource name

### DIFF
--- a/testpmd/hooks/version/ocp4_5.yaml
+++ b/testpmd/hooks/version/ocp4_5.yaml
@@ -1,5 +1,5 @@
 ---
-redhat_catalog_source: redhat-operators
+redhat_catalog_source: mirrored-redhat-operators
 catalog_repo_name: olm
 catalog_image_name: redhat-operators
 catalog_image_version: v1


### PR DESCRIPTION
Red Hat operator catalog is created as part of the installation
itself with a different name 'mirrored-redhat-operators'. Align
the catalog name to install the operators from.