### PR TITLE
Support multiple version of deploy script repo

### DIFF
--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -11,13 +11,13 @@
 
 - name: Deploy NFV Example CNF catalog
   include_role:
-    name: example-cnf-catalog
+    name: "{{ dci_config_dir }}/hooks/{{ cluster_name }}/nfv-example-cnf-deploy/roles/example-cnf-catalog"
 
 - name: Label the nodes for running testpmd and trex
   include_role:
-    name: example-cnf-labels
+    name: "{{ dci_config_dir }}/hooks/{{ cluster_name }}/nfv-example-cnf-deploy/roles/example-cnf-labels"
 
 - name: Deploy the Example CNF applications
   include_role:
-    name: example-cnf-app
+    name: "{{ dci_config_dir }}/hooks/{{ cluster_name }}/nfv-example-cnf-deploy/roles/example-cnf-app"
 

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -52,7 +52,7 @@
 - name: Checkout Example CNF deployment role
   git:
     repo: 'https://github.com/rh-nfv-int/nfv-example-cnf-deploy.git'
-    dest: "{{ dci_config_dir }}/hooks/nfv-example-cnf-deploy"
+    dest: "{{ dci_config_dir }}/hooks/{{ cluster_name }}/nfv-example-cnf-deploy"
     version: "{{ example_cnf_deploy_script_version|default('master') }}"
     update: yes
   register: gitresult

--- a/testpmd/hooks/user-tests.yml
+++ b/testpmd/hooks/user-tests.yml
@@ -1,5 +1,5 @@
 ---
 - name: Run migration test
   include_role:
-    name: example-cnf-validate
+    name: "{{ dci_config_dir }}/hooks/{{ cluster_name }}/nfv-example-cnf-deploy/roles/example-cnf-validate"
   when: run_migration_test|default(true)|bool


### PR DESCRIPTION
nfv-example-cnf-deploy deploy script will use
v0.1 branch for ocp4.4 and v0.2 branch for other
deployments, as LB is not deployed with ocp4.4.
Support clone specific to the cluster so that
parallel jobs on cluster will not alter other
cluster's deploy in progress.