### PR TITLE
Remove support to 4.4 as is now deprecated

### DIFF
--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -1,11 +1,4 @@
 ---
-- name: Label the nodes for running testpmd and trex
-  include_role:
-    name: "{{ dci_config_dir }}/hooks/{{ cluster_name }}/nfv-example-cnf-deploy/roles/example-cnf-labels"
-  when:
-    - ocp_version_maj|int == 4
-    - ocp_version_min|int == 4
-
 - name: Deploy the Example CNF applications
   include_role:
     name: "{{ dci_config_dir }}/hooks/{{ cluster_name }}/nfv-example-cnf-deploy/roles/example-cnf-app"

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -10,9 +10,9 @@
 
 - name: Get OCP version
   set_fact:
-     ocp_version: "{{ '.'.join(item.split(':')[1].strip().split('.')[0:2]) }}"
-     ocp_version_maj: "{{ item.split(':')[1].strip().split('.')[0] }}"
-     ocp_version_min: "{{ item.split(':')[1].strip().split('.')[1] }}"
+    ocp_version: "{{ '.'.join(item.split(':')[1].strip().split('.')[0:2]) }}"
+    ocp_version_maj: "{{ item.split(':')[1].strip().split('.')[0] }}"
+    ocp_version_min: "{{ item.split(':')[1].strip().split('.')[1] }}"
   when: "'Server Version' in item"
   loop: "{{ oc_version_str.stdout_lines }}"
 
@@ -35,20 +35,7 @@
     run_migration_test: false
     mac_workaround_enable: false
 
-- name: Set older version for OCP 4.4 (it requires different CRD change for all operators)
-  set_fact:
-    operator_version: v0.0.1
-    app_version: v0.1.3
-    example_cnf_deploy_script_version: v0.1
-    run_migration_test: true
-    networks:
-      - name: intel-numa0-net1
-        count: 2
-  when:
-    - ocp_version_maj|int == 4
-    - ocp_version_min|int == 4
-
-- name: Set mac workround for ocp 4.4 and 4.5
+- name: Set mac workround for ocp older than 4.6
   set_fact:
     mac_workaround_enable: true
   when:
@@ -57,7 +44,7 @@
 
 - name: Checkout Example CNF deployment role
   git:
-    repo: 'https://github.com/rh-nfv-int/nfv-example-cnf-deploy.git'
+    repo: "https://github.com/rh-nfv-int/nfv-example-cnf-deploy.git"
     dest: "{{ dci_config_dir }}/hooks/{{ cluster_name }}/nfv-example-cnf-deploy"
     version: "{{ example_cnf_deploy_script_version|default('master') }}"
     update: yes
@@ -65,7 +52,7 @@
 
 - debug: msg="Git hash is {{ gitresult.after }}"
 
-- name: 'Install required rpm packages'
+- name: "Install required rpm packages"
   package:
     name:
       - git


### PR DESCRIPTION
OCP 4.4 has been fully EOL back in feb. Removing it's references. 